### PR TITLE
Fix intermittent hangs by being more explicit

### DIFF
--- a/back-end/boards.js
+++ b/back-end/boards.js
@@ -31,6 +31,7 @@ const FLASH_SIZES = {
 class EspBoard {
     constructor(port) {
         this.port = port;
+        this.isInBootLoader = false;
     }
 
     portSet(options) {
@@ -82,6 +83,7 @@ class Esp12 extends EspBoard {
             .then(() => this.portSet({rts: false, dtr: true}))
             .then(() => delay(50))
             .then(() => this.portSet({rts: false, dtr: false}));
+
     }
 }
 


### PR DESCRIPTION
Move bootloader logic to board.  Removes magic number loops.  Listens for successful syncs before getting the party started.

Removes some of the magic number loop stuff I lifted and instead checks a condition.

@chalkers Can you verify this works for you by running it a few time.  It might pause for about 10 seconds, but then should work.  I did 10 successful ones in a row. 
