### PR TITLE
Windows mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
-compiler:
-  - gcc
-  - clang
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 node_js:
     - "5"
     - "6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+compiler:
+  - gcc
+  - clang
 node_js:
     - "5"
     - "6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
     - "5"
+    - "6.0.0"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,25 @@ EP-12 devices like the Adafruit Huzzah and Adadfruit Feather Huzzah.
 
 ## Run the GUI
 
+### OS X
+
 ```bash
 npm install
+npm start
+```
+
+### Windows 10
+
+You'll need installed:
+
+* Visual Studio Community Edition (or better) installed with Windows 8/8.1 SDK.
+* Python 2.7
+
+```
+npm install
+del node_modules\serialport\build\Release\serialport.node
+del node_modules\nslog\build\Release\nslog.node
+npm run rebuild
 npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "bunyan": "^1.8.0",
     "node-binary": "^1.1.0",
-    "nslog": "^3.0.0",
     "request": "^2.72.0",
     "serialport": "^2.0.7-beta1",
     "tar.gz": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "electron index.js",
+    "rebuild": "electron-rebuild",
     "test": "mocha"
   },
   "repository": {
@@ -27,6 +28,7 @@
   "dependencies": {
     "bunyan": "^1.8.0",
     "node-binary": "^1.1.0",
+    "nslog": "^3.0.0",
     "request": "^2.72.0",
     "serialport": "^2.0.7-beta1",
     "tar.gz": "^1.0.3",
@@ -35,6 +37,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "electron-prebuilt": "^0.36.9",
+    "electron-rebuild": "^1.1.3",
     "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
Updated readme to include steps for Windows.
Updated Travis-CI recipe for native modules (docs: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Node.js-v4-(or-io.js-v3)-compiler-requirements)
Added electron-rebuild for rebuilding project.
